### PR TITLE
Update lead modal to request only phone number

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,12 +281,8 @@
           <input type="text" name="name" autocomplete="name" placeholder="Ваше имя" required>
         </label>
         <label class="form__field">
-          <span>Телефон или email</span>
-          <input type="text" name="contact" autocomplete="tel" placeholder="+7 (___) ___‑__‑__" required>
-        </label>
-        <label class="form__field">
-          <span>Комментарий</span>
-          <textarea name="comment" rows="3" placeholder="Расскажите о цели обучения"></textarea>
+          <span>Номер телефона</span>
+          <input type="tel" name="contact" autocomplete="tel" placeholder="+7 (___) ___‑__‑__" required>
         </label>
         <label class="form__agree">
           <input type="checkbox" required>


### PR DESCRIPTION
## Summary
- remove the optional comment field from the lead capture modal
- retitle the contact input so the form only requests a phone number

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e650a31474832ba22b8cdc819f79bc