### PR TITLE
Improve modal consent alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@
         </label>
         <label class="form__agree">
           <input type="checkbox" required>
-          <span>Согласен(на) на обработку персональных данных</span>
+          <span>Согласен(на) на обработку <a href="#" class="form__agree-link">персональных данных</a></span>
         </label>
         <button class="btn btn--primary btn--full" type="submit">Отправить (демо)</button>
         <p class="form__note">Данные выводятся в консоль браузера для тестирования интерфейса.</p>

--- a/styles.css
+++ b/styles.css
@@ -135,6 +135,9 @@ input,textarea{
 input:focus,textarea:focus,.btn:focus{outline:3px solid var(--focus);outline-offset:3px}
 textarea{resize:vertical;min-height:120px}
 .form__agree{display:flex;align-items:center;gap:10px;color:var(--muted);font-size:.95rem}
+.form__agree span{display:inline-flex;align-items:center;gap:4px;white-space:nowrap}
+.form__agree-link{color:var(--accent);text-decoration:none;font-weight:500}
+.form__agree-link:hover{color:var(--text);text-decoration:underline}
 .form__note{margin:6px 0 0;color:var(--muted);font-size:.9rem}
 
 /* ====== Modal ====== */


### PR DESCRIPTION
## Summary
- restyle the modal consent checkbox text to keep the agreement statement on a single line
- add a highlighted link to the personal data policy within the consent text for better clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e658e6bfb8832b879c759f43d4040e