### PR TITLE
Hide modal header content after form submission

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,8 @@
   const closers = modal?.querySelectorAll('[data-modal-close]') || [];
   const form = modal?.querySelector('#lead-form');
   const success = modal?.querySelector('.modal__success');
+  const modalTitle = modal?.querySelector('#modal-title');
+  const modalText = modal?.querySelector('.modal__text');
   let lastFocused = null;
 
   const FOCUSABLE = [
@@ -148,6 +150,8 @@
     document.removeEventListener('keydown', trapFocus);
     success?.setAttribute('hidden','');
     form?.removeAttribute('hidden');
+    modalTitle?.removeAttribute('hidden');
+    modalText?.removeAttribute('hidden');
     lastFocused?.focus();
   }
 
@@ -165,6 +169,8 @@
       console.log('[lead-form] demo submission:', data);
       form.setAttribute('hidden','');
       success?.removeAttribute('hidden');
+      modalTitle?.setAttribute('hidden','');
+      modalText?.setAttribute('hidden','');
     } catch(err){
       console.error('Demo submit failed', err);
     }


### PR DESCRIPTION
## Summary
- hide the modal heading and description after the form submission
- restore the modal intro text when the dialog closes so the next open shows the full form

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e68e700c6c832b9a4d254bcd42da78